### PR TITLE
Guide for adding Vite and TailwindCSS to a WordPress theme

### DIFF
--- a/niko/README.md
+++ b/niko/README.md
@@ -10,6 +10,12 @@ React App within a WordPress Gutenberg Block.
 
 [Guide](react-in-wordpress)
 
+## TailwindCSS in WordPress
+
+This is a guide on how to use Vite to add TailwindCSS to a WordPress theme.
+
+[Guide](tailwind-in-wordpress)
+
 ## Label within textarea
 
 This is a textarea with a label that looks like it sits within it. When the

--- a/niko/tailwind-in-wordpress/README.md
+++ b/niko/tailwind-in-wordpress/README.md
@@ -1,0 +1,90 @@
+# TailwindCSS in WordPress
+
+This guide outlines how to add Vite and TailwindCSS to a WordPress theme, how to
+set up a manifest to properly get the outputted filenames with hashes included
+(to break the cache), and how to properly enqueue the built files.
+
+1. Initialize NPM:
+
+    ```bash
+    npm init
+    ```
+
+2. Install Vite with:
+
+    ```bash
+    npm create vite@latest
+    ```
+
+    and select `Vanilla`
+
+3. Add a Vite config file as `vite.config.js` containing:
+
+    ```js
+    /** @type {import('vite').UserConfig} */
+    export default {
+      build: {
+        rollupOptions: {
+          input: {
+            tailwindcss: "./src/frontend/tailwind.css",
+          },
+        },
+        manifest: true,
+      },
+    };
+    ```
+
+4. Install TailwindCSS and its dependencies, and initialize TailwindCSS:
+
+    ```bash
+    npm install -D tailwindcss postcss autoprefixer
+    npx tailwindcss init -p
+    ```
+
+5. Add the directory/directories containing the template files you're going to
+    use TailwindCSS in to your `tailwind.config.js` file, and add a prefix to
+    avoid conflicts:
+
+    ```js
+    /** @type {import('tailwindcss').Config} */
+    export default {
+      content: ["./src/**/*.{php,html,js,jsx}"],
+      theme: {
+        extend: {},
+      },
+      plugins: [],
+      prefix: "tw-",
+    };
+    ```
+
+6. Set up your TailwindCSS file at `.src/frontend/tailwind.css`:
+
+    ```css
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+    ```
+
+7. Add some functions to your theme to handle getting and enqueueing the outputted
+    files, like those in [Utils.php](Utils.php).
+
+8. Enqueue your outputted scripts with the above functions with something like:
+
+    ```php
+     $this->utils->enqueue_bundled_style('tailwindcss', 'src/frontend/tailwind.css', [], '1.0.0', 'all');
+    ```
+
+9. Add a start script to `package.json` to build as you go:
+
+    ```json
+    "scripts": {
+        "start": "vite build --watch"
+    },
+    ```
+
+10. Start Vite and use TailwindCSS as normal, but with `tw-` prefixing all class
+    names.
+
+        ```bash
+        npm run start
+        ```

--- a/niko/tailwind-in-wordpress/Utils.php
+++ b/niko/tailwind-in-wordpress/Utils.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace ThemeName\lib;
+
+class Utils
+{
+  private array $manifest = [];
+
+  public function __construct()
+  {
+    $this->manifest = $this->get_manifest();
+  }
+
+  /**
+   * Enqueue a script bundled by Vite
+   *
+   * @param string $handle
+   * @param string $path
+   * @param array  $dependencies
+   * @param string $version
+   * @param bool   $in_footer
+   */
+  public function enqueue_bundled_script(string $handle, string $path, array $dependencies = [], string $version = '1.0.0', bool $in_footer = true): void
+  {
+    $manifest_entry = $this->manifest[$path];
+
+    if (isset($manifest_entry)) {
+      $bundled_path = $manifest_entry['file'];
+    } else {
+      return;
+    }
+
+    if (isset($manifest_entry['css'])) {
+      $css_paths = $manifest_entry['css'];
+
+      foreach ($css_paths as $index => $css_path) {
+        $complete_css_path = THEME_NAME_THEME_URL . "/dist/$css_path";
+        wp_enqueue_style("$handle-css-$index", $complete_css_path, [], $version, 'all');
+      }
+    }
+
+    $complete_path = THEME_NAME_THEME_URL . "/dist/$bundled_path";
+
+    wp_enqueue_script($handle, $complete_path, $dependencies, $version, $in_footer);
+  }
+
+  /**
+   * Enqueue a style bundled by Vite
+   *
+   * @param  string $handle
+   * @param  string $path
+   * @param  array  $dependencies
+   * @param  string $version
+   * @param  string $media
+   * @return void
+   */
+  public function enqueue_bundled_style(string $handle, string $path, array $dependencies = [], string $version = '1.0.0', string $media = 'all'): void
+  {
+    $manifest_entry = $this->manifest[$path];
+
+    if (isset($manifest_entry)) {
+      $bundled_path = $manifest_entry['file'];
+    } else {
+      return;
+    }
+
+    $complete_path = THEME_NAME_THEME_URL . "/dist/$bundled_path";
+
+    wp_enqueue_style($handle, $complete_path, $dependencies, $version, $media);
+  }
+
+  /**
+   * Get the Vite manifest file to access bundled assets
+   *
+   * @return array
+   */
+  public function get_manifest(): array
+  {
+    if (!file_exists('wp-content/themes/theme-name/dist/manifest.json')) {
+      return [];
+    }
+
+    $manifest_file = file_get_contents('wp-content/themes/theme-name/dist/manifest.json');
+
+    if (!$manifest_file) {
+      return [];
+    }
+
+    return json_decode($manifest_file, true);
+  }
+}


### PR DESCRIPTION
This just adds a guide to adding Vite and TailwindCSS to a WordPress theme.